### PR TITLE
add extended_ip_address_info.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ So far, the following projects have been integrated to this repo:
 |[Directory organizer](https://github.com/hastagAB/Awesome-Python-Scripts/tree/master/Directory-organizer) | [Athul P](https://github.com/athulpn) |
 |[Excel Files Merger](https://github.com/hastagAB/Awesome-Python-Scripts/tree/master/Excel_Files_Merger) | [Andrei N](https://github.com/Andrei-Niculae)|
 |[Excel to List](https://github.com/hastagAB/Awesome-Python-Scripts/tree/master/Excel_to_ListofList) | [Nitish Srivastava](https://github.com/nitish-iiitd)|
+|[Extended_ip_address_info](https://github.com/hastagAB/Awesome-Python-Scripts/tree/master/extended_ip_address_info) | [hafpaf](https://github.com/hafpaf)|
 |[File explorer](https://github.com/hastagAB/Awesome-Python-Scripts/tree/master/File-Explorer-Dialog-Box) | [Nikhil Kumar Singh](https://github.com/nikhilkumarsingh)|
 |[Flash card quizzer](https://github.com/hastagAB/Awesome-Python-Scripts/tree/master/Flash-card-Challenge) |[Utkarsh Sharma](https://github.com/Utkarsh1308) |
 |[Frammed text generator](https://github.com/hastagAB/Awesome-Python-Scripts/tree/master/FramedText) | [jcdwalle](https://github.com/jcdwalle)|

--- a/extended_ip_address_info/README.md
+++ b/extended_ip_address_info/README.md
@@ -1,0 +1,52 @@
+# Extended IP address info
+
+View extended info about your public IP address from the terminal.
+
+The python script runs `curl` with the following parameters
+```bash
+curl -H "Accept: application/json" https://ipinfo.io/json
+```
+
+## Create virtual environment and run
+Create virtual environment.
+```bash
+python3 -m venv /path/to/new/virtual/environment
+```
+
+Activate virtual environment.
+```bash
+cd <file folder>
+source bin/activate
+```
+
+Install required libraries.
+```bash
+pip install -r requirements.txt
+```
+
+**Run program.**
+```bash
+python extended_ip_address_info.py
+```
+
+Deactivate virtual environment.
+```bash
+deactivate
+```
+
+## Output
+Output should be in the form of the following:
+```json
+{
+  "ip": "xxx.xxx.xxx.xxx",
+  "city": "A_city",
+  "hostname": "host.isp-website.com",
+  "region": "A_region",
+  "country": "Country code",
+  "loc": "coordinates",
+  "org": "AS-number ISP-name",
+  "postal": "postal-code",
+  "timezone": "Europe/City",
+  "readme": "https://ipinfo.io/missingauth"
+}
+```

--- a/extended_ip_address_info/extended_ip_address_info.py
+++ b/extended_ip_address_info/extended_ip_address_info.py
@@ -1,0 +1,28 @@
+#!/bin/python   
+# -*- coding: utf-8 -*-
+
+# Using curl to get data from https://ipinfo.io/json
+# Template from pycurl documentation
+# http://pycurl.io/docs/latest/quickstart.html#examining-response-headers
+
+import pycurl #curl library
+import certifi #HTTP over TLS/SSL library
+from io import BytesIO #Buffered I/O implementation using an in-memory bytes buffer.
+
+#set header, '--header' or -H
+header = ['Accept: application/json']
+
+buffer = BytesIO()
+c = pycurl.Curl() #curl
+c.setopt(c.HTTPHEADER, header) #header
+c.setopt(c.URL, 'https://ipinfo.io/json') #URL
+c.setopt(c.WRITEDATA, buffer)
+c.setopt(c.CAINFO, certifi.where()) # SSL certificates
+c.perform()
+c.close()
+
+body = buffer.getvalue()
+# Body is a byte string.
+# We have to know the encoding in order to print it to a text file
+# such as standard output.
+print(body.decode('iso-8859-1'))

--- a/extended_ip_address_info/requirements.txt
+++ b/extended_ip_address_info/requirements.txt
@@ -1,0 +1,2 @@
+pycurl
+certifi


### PR DESCRIPTION
# Purpose
View extended info about your public IP address from the terminal.

# Files
Add extended_ip_address_info/extended_ip_address_info.py
Add extended_ip_address_info.py/README.md
Add extended_ip_address_info/requirements.txt
Edit README.md

# Details
The python script uses the *pycurl* library to run `curl` with the following parameters
```bash
curl -H "Accept: application/json" https://ipinfo.io/json
```